### PR TITLE
Exposing codeVerifier inside LoginSession for external server exchange token

### DIFF
--- a/GrabIdPartnerSDK/build.gradle
+++ b/GrabIdPartnerSDK/build.gradle
@@ -50,7 +50,7 @@ ext {
     gitUrl = 'https://github.com/grab/grabidpartnersdk-android.git'
     githubRepository= 'grab/grabplatform-sdk-android'
 
-    libraryVersion = '1.0.3' // Current version of .aar in JCenter
+    libraryVersion = '1.0.4' // Current version of .aar in JCenter
 
     licenseName = 'The MIT License'
     licenseUrl = 'https://opensource.org/licenses/MIT'

--- a/GrabIdPartnerSDK/src/main/java/com/grab/partner/sdk/GrabIdPartner.kt
+++ b/GrabIdPartnerSDK/src/main/java/com/grab/partner/sdk/GrabIdPartner.kt
@@ -126,7 +126,7 @@ class GrabIdPartner private constructor() : GrabIdPartnerProtocol {
             return
         }
         var loginSession = LoginSession()
-        loginSession.codeVerifier = utility.generateCodeVerifier()
+        loginSession.codeVerifierInternal = utility.generateCodeVerifier()
         loginSession.stateInternal = utility.getRandomString()
         loginSession.nonceInternal = utility.getRandomString()
         loginSession.codeChallenge = utility.generateCodeChallenge(loginSession.codeVerifier)

--- a/GrabIdPartnerSDK/src/main/java/com/grab/partner/sdk/models/LoginSession.kt
+++ b/GrabIdPartnerSDK/src/main/java/com/grab/partner/sdk/models/LoginSession.kt
@@ -32,7 +32,8 @@ class LoginSession {
     internal var codeInternal: String = EMPTY_STRING_CONST
     val code get() = codeInternal
 
-    internal var codeVerifier: String = EMPTY_STRING_CONST
+    internal var codeVerifierInternal: String = EMPTY_STRING_CONST
+    val codeVerifier get() = codeVerifierInternal
 
     internal var accessTokenExpiresAtInternal: Date? = null
     val accessTokenExpiresAt get() = accessTokenExpiresAtInternal

--- a/GrabIdPartnerSDK/src/main/java/com/grab/partner/sdk/utils/Utility.kt
+++ b/GrabIdPartnerSDK/src/main/java/com/grab/partner/sdk/utils/Utility.kt
@@ -303,7 +303,7 @@ internal class Utility(var context: Context) : IUtility {
             clientId = source.clientId
             scope = source.scope
             codeInternal = source.code
-            codeVerifier = source.codeVerifier
+            codeVerifierInternal = source.codeVerifier
             stateInternal = source.state
             tokenTypeInternal = source.tokenType
             nonceInternal = source.nonce
@@ -325,7 +325,7 @@ internal class Utility(var context: Context) : IUtility {
         loginSession.clientId = ""
         loginSession.scope = ""
         loginSession.codeInternal = ""
-        loginSession.codeVerifier = ""
+        loginSession.codeVerifierInternal = ""
         loginSession.stateInternal = ""
         loginSession.tokenTypeInternal = ""
         loginSession.nonceInternal = ""

--- a/GrabIdPartnerSDK/src/test/java/com/grab/partner/sdk/GrabIdPartnerTest.kt
+++ b/GrabIdPartnerSDK/src/test/java/com/grab/partner/sdk/GrabIdPartnerTest.kt
@@ -157,6 +157,13 @@ class GrabIdPartnerTest {
     }
 
     @Test
+    fun `verify loginSession has required parameters after loadLoginSession`() {
+        prerequisiteToValidateLoadLoginSessionWithDifferentPartnerinfo(FAKE_CLIENT_ID, FAKE_REDIRECT_URI, FAKE_DISCOVERY_URL, PARTNER_SCOPE)
+        loginSessionCallback.verifyOnSuccess(1)
+        loginSessionCallback.verifyAllRequiredParametersExists()
+    }
+
+    @Test
     fun `verify login with empty client id`() {
         prerequisiteToValidateLogin("", "", "", "")
 
@@ -512,6 +519,13 @@ class TestLoginSessionCallback : LoginSessionCallback {
 
     fun verifyOnSuccess(i: Int) {
         Mockito.verify(mockLoginSessionCallback, Times(i)).onSuccess(any())
+    }
+
+    fun verifyAllRequiredParametersExists(){
+        Assert.assertTrue(!this.loginSession?.codeVerifier.isNullOrBlank())
+        Assert.assertTrue(!this.loginSession?.state.isNullOrBlank())
+        Assert.assertTrue(!this.loginSession?.nonce.isNullOrBlank())
+        Assert.assertTrue(!this.loginSession?.codeChallenge.isNullOrBlank())
     }
 
     fun verifyOnError(expected: GrabIdPartnerError): Boolean {

--- a/sampleapp-java/build.gradle
+++ b/sampleapp-java/build.gradle
@@ -47,5 +47,5 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 
     // dependency on GrabIdPartnerSDK sdk
-    implementation 'com.grab.grabidpartnersdk:GrabIdPartnerSDK:1.0.3'
+    implementation 'com.grab.grabidpartnersdk:GrabIdPartnerSDK:1.0.4'
 }

--- a/sampleapp-kotlin/build.gradle
+++ b/sampleapp-kotlin/build.gradle
@@ -65,5 +65,5 @@ dependencies {
     implementation 'com.squareup.okhttp3:logging-interceptor:3.11.0'
 
     // dependency on GrabIdPartnerSDK sdk
-    implementation 'com.grab.grabidpartnersdk:GrabIdPartnerSDK:1.0.3'
+    implementation 'com.grab.grabidpartnersdk:GrabIdPartnerSDK:1.0.4'
 }


### PR DESCRIPTION
`codeVerifier` is required to be exposed so partners can exchange token with their own server. Previously it was not exposed inside LoginSession.